### PR TITLE
Replace relative to absolute path for `cov-clang.sh`

### DIFF
--- a/cov-generate.sh
+++ b/cov-generate.sh
@@ -21,7 +21,7 @@ test -d "$1" || { echo Error: directory $1 does not exist; exit 1; }
 test -x "$2" || { echo Error: $2 is not an executable; exit 1; }
 
 OPT=
-test -n "$CLANG" && OPT="--gcov-tool cov-clang.sh"
+test -n "$CLANG" && OPT="--gcov-tool $PWD/cov-clang.sh"
 
 DIR=`dirname $0`
 test -n "$DIR" && export PATH=$PATH:$DIR

--- a/cov-generate.sh
+++ b/cov-generate.sh
@@ -27,12 +27,12 @@ DIR=`dirname $0`
 test -n "$DIR" && export PATH=$PATH:$DIR
 
 mkdir report 2> /dev/null
-lcov $OPT --no-checksum --zerocounters --directory . || exit
-lcov $OPT --no-checksum --capture --initial --directory . --output-file report/trace.lcov_base || exit 1
+lcov $OPT --no-checksum --ignore-errors inconsistent,unsupported --zerocounters --directory . || exit
+lcov $OPT --no-checksum --ignore-errors inconsistent,unsupported --capture --initial --directory . --output-file report/trace.lcov_base || exit 1
 "$2" "$1"/*
-lcov $OPT --no-checksum --capture --directory . --output-file report/trace.lcov_info || exit 1
-lcov $OPT --no-checksum -a report/trace.lcov_base -a report/trace.lcov_info --output-file report/trace.lcov_tmp || exit 1
-lcov $OPT --no-checksum -r report/trace.lcov_tmp /usr/include/\*  --output-file report/trace.lcov_info_final || exit 1
-genhtml --ignore-errors source --output-directory report report/trace.lcov_info_final
+lcov $OPT --no-checksum --ignore-errors inconsistent,unsupported --capture --directory . --output-file report/trace.lcov_info || exit 1
+lcov $OPT --no-checksum --ignore-errors inconsistent,unsupported -a report/trace.lcov_base -a report/trace.lcov_info --output-file report/trace.lcov_tmp || exit 1
+lcov $OPT --no-checksum --ignore-errors inconsistent,unsupported -r report/trace.lcov_tmp /usr/include/\*  --output-file report/trace.lcov_info_final || exit 1
+genhtml --ignore-errors source,format --output-directory report report/trace.lcov_info_final
 echo
 echo Report: `pwd`/report/index.html


### PR DESCRIPTION
When being on top directory, this fixes the following warning: `stderr: geninfo: WARNING: Can't exec "./cov-clang.sh": No such file or directory`.